### PR TITLE
Add tests for visiting the root route

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,8 @@ defmodule NewsletterCodeChallenge.Mixfile do
       {:cowboy, "~> 1.0"},
       {:coherence, "~> 0.5"},
       {:swoosh, "~> 0.9.0"},
-      {:gen_smtp, "~> 0.12.0"}
+      {:gen_smtp, "~> 0.12.0"},
+      {:ex_machina, "~> 2.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,7 @@
   "ecto": {:hex, :ecto, "2.1.6", "29b45f393c2ecd99f83e418ea9b0a2af6078ecb30f401481abac8a473c490f84", [], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
   "ex_admin": {:git, "https://github.com/smpallen99/ex_admin.git", "18b0435d640eb501bc1c86937bafaf5204c1724d", []},
+  "ex_machina": {:hex, :ex_machina, "2.0.0", "ec284c6f57233729cea9319e083f66e613e82549f78eccdb2059aeba5d0df9f3", [], [{:ecto, "~> 2.1", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_queb": {:hex, :ex_queb, "1.0.0", "d4bdc430913c1d083f8b10b2bc0034b51aa32cdda760cf10773a31e8dd5f3786", [], [{:ecto, "~> 2.0", [hex: :ecto, repo: "hexpm", optional: false]}], "hexpm"},
   "exactor": {:hex, :exactor, "2.2.3", "a6972f43bb6160afeb73e1d8ab45ba604cd0ac8b5244c557093f6e92ce582786", [], [], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [], [], "hexpm"},

--- a/test/newsletter_code_challenge_web/controllers/page_controller_test.exs
+++ b/test/newsletter_code_challenge_web/controllers/page_controller_test.exs
@@ -19,5 +19,15 @@ defmodule NewsletterCodeChallengeWeb.PageControllerTest do
 
       assert html_response(conn, 200) =~ "Create a newsletter"
     end
+
+    test "tells a signed in user (which shouldn't happen) to bugger off", %{conn: conn} do
+      user = insert(:user)
+
+      conn = conn
+      |> assign(:current_user, user)
+      |> get("/")
+
+      assert html_response(conn, 200) =~ "Bugger off!"
+    end
   end
 end

--- a/test/newsletter_code_challenge_web/controllers/page_controller_test.exs
+++ b/test/newsletter_code_challenge_web/controllers/page_controller_test.exs
@@ -1,8 +1,23 @@
 defmodule NewsletterCodeChallengeWeb.PageControllerTest do
   use NewsletterCodeChallengeWeb.ConnCase
+  import NewsletterCodeChallenge.Factory
+  use ExUnit.Case, async: true
 
-  test "GET /", %{conn: conn} do
-    conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+  describe "GET /" do
+    test "visitor gets redirected to the newsletteer sign up page", %{conn: conn} do
+      conn = get conn, "/"
+      assert html_response(conn, 302)
+      assert redirected_to(conn) == registration_path(conn, :new)
+    end
+
+    test "signed in admin sees the create newsletter button", %{conn: conn} do
+      admin = insert(:admin)
+
+      conn = conn
+      |> assign(:current_user, admin)
+      |> get("/")
+
+      assert html_response(conn, 200) =~ "Create a newsletter"
+    end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,0 +1,13 @@
+defmodule NewsletterCodeChallenge.Factory do
+  use ExMachina.Ecto, repo: NewsletterCodeChallenge.Repo
+  alias NewsletterCodeChallenge.Coherence.User
+
+  def admin_factory do
+    %User{
+      email: "admin@example.com",
+      password: "adminpass",
+      password_confirmation: "adminpass",
+      role: "admin"
+    }
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -10,4 +10,12 @@ defmodule NewsletterCodeChallenge.Factory do
       role: "admin"
     }
   end
+
+  def user_factory do
+    %User{
+      email: "user@example.com",
+      password: "userpass",
+      password_confirmation: "userpass"
+    }
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,3 +2,4 @@ ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(NewsletterCodeChallenge.Repo, :manual)
 
+{:ok, _} = Application.ensure_all_started(:ex_machina)


### PR DESCRIPTION
Three test for the page_controller (solely used for the default root page as generated when creating a Phoenix project). Also added `ex_machina` for creating factories for the admin and user to use in the rest of the tests.

1. Visitor gets redirected to the newsletter sign up page.
2. Signed in admin sees the create newsletter button.
3. Tells a signed in user (which shouldn't happen) to bugger off.