### PR TITLE
Add tests for the newsletter controller

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -17,3 +17,6 @@ config :newsletter_code_challenge, NewsletterCodeChallenge.Repo,
   database: "newsletter_code_challenge_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :newsletter_code_challenge, NewsletterCodeChallengeWeb.SendgridMailer,
+  adapter: Swoosh.Adapters.Test

--- a/lib/newsletter_code_challenge_web/controllers/newsletter_controller.ex
+++ b/lib/newsletter_code_challenge_web/controllers/newsletter_controller.ex
@@ -7,7 +7,12 @@ defmodule NewsletterCodeChallengeWeb.NewsletterController do
   alias NewsletterCodeChallenge.Repo
 
   def new(conn, _params) do
-    render(conn, "new.html")
+    if conn.assigns.current_user do
+      render(conn, "new.html")
+    else
+      conn
+      |> redirect(to: registration_path(conn, :new))
+    end
   end
 
   def create(conn, params) do

--- a/lib/newsletter_code_challenge_web/templates/newsletter/new.html.eex
+++ b/lib/newsletter_code_challenge_web/templates/newsletter/new.html.eex
@@ -1,18 +1,22 @@
-<h1>Create a newsletter</h1>
+<%= if @conn.assigns[:current_user].role == "admin" do %>
+  <h1>Create a newsletter</h1>
 
-<%= form_for @conn, newsletter_path(@conn, :create), [as: :newsletter], fn f -> %>
+  <%= form_for @conn, newsletter_path(@conn, :create), [as: :newsletter], fn f -> %>
 
-  <div class="form-group">
-    <%= label f, "Subject", class: "control-label" %>
-    <%= text_input f, :subject, class: "form-control", required: "" %>
-  </div>
+    <div class="form-group">
+      <%= label f, "Subject", class: "control-label" %>
+      <%= text_input f, :subject, class: "form-control", required: "" %>
+    </div>
 
-  <div class="form-group">
-    <%= label f, "Body", class: "control-label" %>
-    <%= textarea f, :body, class: "form-control", required: "" %>
-  </div>
+    <div class="form-group">
+      <%= label f, "Body", class: "control-label" %>
+      <%= textarea f, :body, class: "form-control", required: "" %>
+    </div>
 
-  <div class="form-group">
-    <%= submit "Send newsletter", class: "btn btn-primary" %>
-  </div>
+    <div class="form-group">
+      <%= submit "Send newsletter", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+<% else %>
+  <h1>Bugger off!</h1>
 <% end %>

--- a/test/newsletter_code_challenge_web/controllers/newsletter_controller_test.exs
+++ b/test/newsletter_code_challenge_web/controllers/newsletter_controller_test.exs
@@ -1,7 +1,8 @@
 defmodule NewsletterCodeChallengeWeb.NewsletterControllerTest do
   use NewsletterCodeChallengeWeb.ConnCase
-  import NewsletterCodeChallenge.Factory
   use ExUnit.Case, async: true
+
+  import NewsletterCodeChallenge.Factory
 
   describe "GET /newsletter/new" do
     test "redirects visitor to the newsletter sign up page", %{conn: conn} do
@@ -30,6 +31,22 @@ defmodule NewsletterCodeChallengeWeb.NewsletterControllerTest do
       |> get(newsletter_path(conn, :new))
 
       assert html_response(conn, 200) =~ "Bugger off!"
+    end
+  end
+
+  describe "POST /newsletter" do
+    test "creates a newsletter and emails it to subscribers", %{conn: conn} do
+      user = insert(:user, email: "user2@example.com")
+      newsletter = %{"newsletter" => %{"subject" => "Hello", "body" => "This is a test"}}
+
+      conn = conn
+      |> post(newsletter_path(conn, :create), params: newsletter)
+
+      email =  NewsletterCodeChallenge.NewsletterEmail.newsletter(user, newsletter)
+
+      assert email.subject == newsletter["newsletter"]["subject"]
+      assert html_response(conn, 302)
+      assert get_flash(conn, :success) == "Your newsletter was successfully sent!"
     end
   end
 end

--- a/test/newsletter_code_challenge_web/controllers/newsletter_controller_test.exs
+++ b/test/newsletter_code_challenge_web/controllers/newsletter_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule NewsletterCodeChallengeWeb.NewsletterControllerTest do
+  use NewsletterCodeChallengeWeb.ConnCase
+  import NewsletterCodeChallenge.Factory
+  use ExUnit.Case, async: true
+
+  describe "GET /newsletter/new" do
+    test "redirects visitor to the newsletter sign up page", %{conn: conn} do
+      conn = conn
+      |> get(newsletter_path(conn, :new))
+
+      assert html_response(conn, 302)
+      assert redirected_to(conn) == registration_path(conn, :new)
+    end
+
+    test "renders newsletter form for a signed in admin", %{conn: conn} do
+      admin = insert(:admin)
+
+      conn = conn
+      |> assign(:current_user, admin)
+      |> get(newsletter_path(conn, :new))
+
+      assert html_response(conn, 200) =~ "Send newsletter"
+    end
+
+    test "tells a signed in user (which shouldn't happen) to bugger off", %{conn: conn} do
+      user = insert(:user)
+
+      conn = conn
+      |> assign(:current_user, user)
+      |> get(newsletter_path(conn, :new))
+
+      assert html_response(conn, 200) =~ "Bugger off!"
+    end
+  end
+end

--- a/test/newsletter_code_challenge_web/controllers/page_controller_test.exs
+++ b/test/newsletter_code_challenge_web/controllers/page_controller_test.exs
@@ -4,13 +4,13 @@ defmodule NewsletterCodeChallengeWeb.PageControllerTest do
   use ExUnit.Case, async: true
 
   describe "GET /" do
-    test "visitor gets redirected to the newsletteer sign up page", %{conn: conn} do
+    test "redirects visitor to the newsletter sign up page", %{conn: conn} do
       conn = get conn, "/"
       assert html_response(conn, 302)
       assert redirected_to(conn) == registration_path(conn, :new)
     end
 
-    test "signed in admin sees the create newsletter button", %{conn: conn} do
+    test "shows the button for creating a newsletter to a signed in admin", %{conn: conn} do
       admin = insert(:admin)
 
       conn = conn


### PR DESCRIPTION
This set of tests is similar to the `page_controller :index` as far as who should see the form.

1. Visitor gets redirected to the newsletter sign up page.
2. Signed in admin sees the create newsletter button.
3. Tells a signed in user (which shouldn't happen) to bugger off.

There is also an additional test to make sure our `NewsletterEmail` module returns an email struct whose email subject are the same as the params submitted in the post. It also asserts a redirect and flashes a success message.