### PR TITLE
Remove hidden password field for sign up

### DIFF
--- a/lib/newsletter_code_challenge/coherence/user.ex
+++ b/lib/newsletter_code_challenge/coherence/user.ex
@@ -20,7 +20,6 @@ defmodule NewsletterCodeChallenge.Coherence.User do
     |> validate_required([:name, :email])
     |> validate_format(:email, ~r/@/)
     |> unique_constraint(:email)
-    |> validate_coherence(params)
   end
 
   def changeset(model, params, :password) do

--- a/lib/newsletter_code_challenge_web/templates/coherence/registration/form.html.eex
+++ b/lib/newsletter_code_challenge_web/templates/coherence/registration/form.html.eex
@@ -20,23 +20,6 @@
     <%= error_tag f, :email %>
   </div>
 
-  <%= if Coherence.Config.require_current_password and not is_nil(@changeset.data.id) do %>
-    <div class="form-group">
-      <%= hidden_input f, :current_password, class: "form-control", required: "", value: "doesntmatteratallreally" %>
-      <%= error_tag f, :current_password %>
-    </div>
-  <% end %>
-
-  <div class="form-group">
-    <%= hidden_input f, :password, class: "form-control", required: "", value: "doesntmatteratallreally" %>
-    <%= error_tag f, :password %>
-  </div>
-
-  <div class="form-group">
-    <%= hidden_input f, :password_confirmation, class: "form-control", required: "", value: "doesntmatteratallreally" %>
-    <%= error_tag f, :password_confirmation %>
-  </div>
-
   <div class="form-group">
     <%= submit "Sign up", class: "btn btn-primary" %>
     <%= link dgettext("coherence", "Cancel"), to: Coherence.Config.logged_out_url("/"), class: "btn" %>


### PR DESCRIPTION
The user sign up form for the newsletter no longer has hidden fields for
sending a default password in the form. This was initially done because
of time contraints and not being able to find where in Coherence's
functions I could bypass the password. Removing the password field from
the schema caused problems as did trying to set a default password
within the schema.

Within the changeset in coherence/user.ex there was a function call of
validate_password/2. By removing that, the form submission would not try
to validate the password and it would just get set to nil and the user
email added to the databse. This has the added benefit of not allowing a
non-admin to sign in as they cannot submitted a nil for the password.

This would allow the removal of checks in the template to ensure only
admins can see the admin dashboard and send a newsletter *if* we purged
the database and started over. Since that isn't being done, the checks
will stay put and the tests for it in place.

All tests are green.